### PR TITLE
Setup config file for handling client settings/info

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,6 @@ dist-ssr
 *.njsproj
 *.sln
 *.sw?
+
+# Config Files
+config.json

--- a/src/components/UI/AppHeader.vue
+++ b/src/components/UI/AppHeader.vue
@@ -9,6 +9,7 @@ import Avatar from '@/components/UI/Avatar.vue'
 // Pinia
 import { storeToRefs } from 'pinia'
 import { usePrimaryStore } from '@/stores/primaryStore'
+import { useRuntimeStore } from '@/stores/runtimeStore'
 const props = defineProps({
     textClass: {
         type: String,
@@ -28,6 +29,7 @@ const toggleDark = useToggle(isDark)
 const { showSidebar } = storeToRefs(usePrimaryStore())
 const { toggleSidebar } = usePrimaryStore()
 const { width } = useWindowSize()
+const { clientName, configOptions } = storeToRefs(useRuntimeStore())
 
 watch(width, (newWidth) => {
     if (newWidth > 768) {
@@ -46,9 +48,7 @@ onMounted(() => {
 })
 
 import { useModalStore } from '@/stores/modalStore'
-const { avatarModal } = storeToRefs(
-    useModalStore()
-)
+const { avatarModal } = storeToRefs(useModalStore())
 const { notificationModalContent, notificationModal } = storeToRefs(
     useModalStore()
 )
@@ -56,9 +56,9 @@ const classes = getStyles(props, 'notificationModal')
 </script>
 
 <template>
-    <section class="p-2 border-b border-gray-600 shadow-md flex-ie-jend ">
+    <section class="p-2 border-b border-gray-600 shadow-md flex-ie-jend">
         <h3 class="w-full text-xl font-bold primary-text md:hidden">
-            New Client
+            {{ configOptions.clientName }}
         </h3>
         <div class="gap-2 flex-ie-jend">
             <Button v-if="width < 768" @click="toggleSidebar()" text="Bar" />
@@ -71,7 +71,8 @@ const classes = getStyles(props, 'notificationModal')
                     {{ notificationModalContent.length }}
                 </span>
             </section>
-            <Avatar avatar-class="cursor-pointer size-10" 
+            <Avatar
+                avatar-class="cursor-pointer size-10"
                 @click="avatarModal.toggle"
             />
             <Button
@@ -79,6 +80,5 @@ const classes = getStyles(props, 'notificationModal')
                 :text="isDark ? '&#9788;' : '&#9789;'"
             />
         </div>
-        
     </section>
 </template>

--- a/src/components/UI/Sidedrawer.vue
+++ b/src/components/UI/Sidedrawer.vue
@@ -6,6 +6,7 @@ import { useWindowSize } from '@vueuse/core'
 
 // Pinia
 import { usePrimaryStore } from '@/stores/primaryStore'
+import { useRuntimeStore } from '@/stores/runtimeStore'
 // Utils
 import { getStyles } from '@/composables/getStyles'
 const props = defineProps({
@@ -34,6 +35,9 @@ const props = defineProps({
         default: '',
     },
 })
+
+const { configOptions } = storeToRefs(useRuntimeStore())
+
 const { showSidebar } = storeToRefs(usePrimaryStore())
 const { toggleSidebar } = usePrimaryStore()
 const { width } = useWindowSize()
@@ -51,7 +55,7 @@ const classes = getStyles(props, 'sidebar')
 
 <template>
     <transition name="fade">
-        <section >
+        <section>
             <div
                 v-if="showSidebar"
                 id="backdrop"
@@ -60,7 +64,9 @@ const classes = getStyles(props, 'sidebar')
             ></div>
 
             <section v-if="showSidebar" :class="classes.containerClass">
-                <h3 :class="classes.titleClass">New Client</h3>
+                <h3 :class="classes.titleClass">
+                    {{ configOptions.clientName }}
+                </h3>
                 <div :class="classes.navContainerClass">
                     <RouterLink
                         to="/"

--- a/src/main.js
+++ b/src/main.js
@@ -1,9 +1,23 @@
 import { createApp } from 'vue'
 import { createPinia } from 'pinia'
-import VueApexCharts from "vue3-apexcharts";
+import VueApexCharts from 'vue3-apexcharts'
 import router from '@/router'
 import './style.css'
 import App from './App.vue'
+// Pinia
+import { useRuntimeStore } from './stores/runtimeStore'
+import { storeToRefs } from 'pinia'
 
-const pinia = createPinia()
-createApp(App).use(pinia).use(router).use(VueApexCharts).mount('#app')
+const initializeApp = async () => {
+    // Fetch and parse the config file
+    const configResponse = await fetch('/config.json')
+    const configJson = await configResponse.json()
+    const pinia = createPinia()
+    createApp(App).use(pinia).use(router).use(VueApexCharts).mount('#app')
+
+    // Set config vars after app is initialized.
+    const { configOptions } = storeToRefs(useRuntimeStore())
+    configOptions.value = configJson
+}
+
+initializeApp()

--- a/src/stores/runtimeStore.js
+++ b/src/stores/runtimeStore.js
@@ -1,0 +1,20 @@
+import { ref } from 'vue'
+import { defineStore } from 'pinia'
+
+export const useRuntimeStore = defineStore('runtimeStore', () => {
+    const clientName = ref('')
+    const configOptions = ref({
+        clientName: 'New Client',
+    })
+
+    const values = {
+        clientName,
+        configOptions,
+    }
+    const actions = {}
+
+    return {
+        ...values,
+        ...actions,
+    }
+})


### PR DESCRIPTION
Adds ability to set values for a client from a config.json file in the **project root**. This file was added to the gitignore because it will most definitely contain sensitive info in the future.

The only prop set up currently is `clientName` and this is reflected AppHeader and Sidedrawer components.

The file will contain just a JSON object.

```shell
{
  "clientName": "Cool Dudes",
  ... any other ol crap you may need...
}
```